### PR TITLE
Update index.js

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -121,7 +121,7 @@ if (cluster.isMaster) {
           grant_type: 'authorization_code',
         },
         headers: {
-          Authorization: `Basic ${new Buffer(`${CLIENT_ID}:${CLIENT_SECRET}`).toString('base64')}`,
+          Authorization: `Basic ${new Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString('base64')}`,
         },
         json: true,
       };


### PR DESCRIPTION
(node:18436) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.